### PR TITLE
Chore: vocal_dataのアップロード先をAWS S3に変更 

### DIFF
--- a/app/uploaders/vocal_data_uploader.rb
+++ b/app/uploaders/vocal_data_uploader.rb
@@ -5,8 +5,8 @@ class VocalDataUploader < CarrierWave::Uploader::Base
   include CarrierWave::Audio
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,7 +5,7 @@ require 'carrierwave/storage/fog'
 CarrierWave.configure do |config|
   config.storage :fog
   config.fog_provider = 'fog/aws'
-  config.fog_directory = 'gruntchecker_audios'
+  config.fog_directory = 'gruntchecker-audios'
   config.fog_credentials = {
     provider: 'AWS',
     aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],


### PR DESCRIPTION
## 概要
close #22
`app/uploaders/vocal_data_uploader.rb`の設定を変更し、`vocal_data`がAWS S3にアップロードされるようにしました。

## 確認方法
録音のページで音声を録音し、結果ページにて埋め込まれた音声が再生できるか確認

## コメント
現在は環境問わずS3にアップロードされるようになっているが、状況に応じてテスト・開発環境はローカルにアップロードするように変更する可能性あり。