### PR TITLE
Feat: お手本ボーカル・演奏データのアップロード

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,12 +45,12 @@ a {
 }
 
 .main {
-  padding-top: 64px;
+  padding: 64px 0 68px;
 }
 
 .top {
   margin-top: 56px;
-  padding-bottom: 80px;
+  padding-bottom: 20px;
 
   &-title {
     img {
@@ -110,9 +110,8 @@ a {
     max-width: 680px;
   }
 
-  .main-controls {
+  .controls {
     padding-bottom: 0.7rem;
-    height: 100%;
   }
 
   .sound-clips {

--- a/app/controllers/recordings_controller.rb
+++ b/app/controllers/recordings_controller.rb
@@ -1,5 +1,5 @@
 class RecordingsController < ApplicationController
-  before_action :set_recording, only: %i[show]
+  before_action :set_recording, only: %i[show edit update]
 
   def index
     @recordings = Recording.all
@@ -7,7 +7,21 @@ class RecordingsController < ApplicationController
 
   def show; end
 
+  def edit; end
+
+  def update
+    if @recording.update(recording_params)
+      redirect_to recordings_path
+    else
+      render :edit
+    end
+  end
+
   private
+
+  def recording_params
+    params.require(:recording).permit(:vocal_style, :instruments, :example_vocal)
+  end
 
   def set_recording
     @recording = Recording.find(params[:id])

--- a/app/javascript/packs/voice.js
+++ b/app/javascript/packs/voice.js
@@ -9,6 +9,8 @@ const jsPlaybackButton = document.getElementById('js-playback-button');
 const jsPlayer = document.getElementById('js-player');
 const jsDownloadLink = document.getElementById('js-download-link');
 const jsResultButton = document.getElementById('js-result-button');
+const jsExampleButton = document.getElementById('js-example-button');
+const jsExamplePlayer = document.getElementById('js-example-player');
 
 let audioData = [];
 let bufferSize = 1024;
@@ -23,7 +25,7 @@ let timeout = null;
 let onAudioProcess = function(e) {
   let input = e.inputBuffer.getChannelData(0);
   let bufferData = new Float32Array(bufferSize);
-  for (var i = 0; i < bufferSize; i++) {
+  for (let i = 0; i < bufferSize; i++) {
     bufferData[i] = input[i];
   }
   audioData.push(bufferData)
@@ -161,7 +163,7 @@ jsStopButton.onclick = function() {
   jsResultButton.disabled = false;
 }
 
-jsPlaybackButton.onclick = function(audioBlob) {
+jsPlaybackButton.onclick = function() {
   if(micBlobUrl) {
     jsPlayer.src = micBlobUrl;
     jsPlayer.onended = function() {
@@ -172,18 +174,22 @@ jsPlaybackButton.onclick = function(audioBlob) {
   }
 }
 
+jsExampleButton.onclick = function() {
+  jsExamplePlayer.play();
+}
+
 jsResultButton.onclick = function() {
   jsResultButton.disabled = true;
-  var xhr = new XMLHttpRequest();
-  xhr.open('GET', document.querySelector('#js-download-link').href, true);
+  let xhr = new XMLHttpRequest();
+  xhr.open('GET', document.getElementById('js-download-link').href, true);
   xhr.responseType = 'blob';
   xhr.send();
-  xhr.onload = function(e) {
-    var myBlob = this.response;
+  xhr.onload = function() {
+    let myBlob = this.response;
     let formData = new FormData();
-    formData.append('recording_id', document.querySelector('#recording_id').value)
+    formData.append('recording_id', document.getElementById('recording_id').value)
     formData.append('vocal_data', myBlob, 'vocal.wav');
-    axios.post(document.querySelector('#voiceform').action, formData, {
+    axios.post(document.getElementById('voiceform').action, formData, {
       headers: {
         'content-type': 'multipart/form-data',
       }
@@ -194,4 +200,4 @@ jsResultButton.onclick = function() {
         console.log(error.response)
     })
   } 
-  }
+}

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -16,6 +16,7 @@
 class Recording < ApplicationRecord
   has_many :results, dependent: :delete_all
   mount_uploader :instruments, InstrumentsUploader
+  mount_uploader :example_vocal, ExampleVocalUploader
 
   validates :vocal_style, presence: true, uniqueness: true
 end

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -11,14 +11,10 @@
 #
 # Indexes
 #
-#  index_recordings_on_example_vocal  (example_vocal) UNIQUE
-#  index_recordings_on_instruments    (instruments) UNIQUE
-#  index_recordings_on_vocal_style    (vocal_style) UNIQUE
+#  index_recordings_on_vocal_style  (vocal_style) UNIQUE
 #
 class Recording < ApplicationRecord
   has_many :results, dependent: :delete_all
 
   validates :vocal_style, presence: true, uniqueness: true
-  validates :example_vocal, uniqueness: true, allow_blank: true
-  validates :instruments, uniqueness: true, allow_blank: true
 end

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -15,6 +15,7 @@
 #
 class Recording < ApplicationRecord
   has_many :results, dependent: :delete_all
+  mount_uploader :instruments, InstrumentsUploader
 
   validates :vocal_style, presence: true, uniqueness: true
 end

--- a/app/uploaders/example_vocal_uploader.rb
+++ b/app/uploaders/example_vocal_uploader.rb
@@ -1,0 +1,47 @@
+class ExampleVocalUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  # storage :file
+  storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/uploaders/instruments_uploader.rb
+++ b/app/uploaders/instruments_uploader.rb
@@ -1,0 +1,48 @@
+class InstrumentsUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+  include CarrierWave::Audio
+
+  # Choose what kind of storage to use for this uploader:
+  # storage :file
+  storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/uploaders/vocal_data_uploader.rb
+++ b/app/uploaders/vocal_data_uploader.rb
@@ -11,7 +11,7 @@ class VocalDataUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.uuid}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/app/views/recordings/edit.html.erb
+++ b/app/views/recordings/edit.html.erb
@@ -1,0 +1,14 @@
+<div class="container mt-5" style="width: 400px">
+  <h1 class="my-5 text-center" style="font-size: 2rem">編集画面（仮）</h1>
+  <%= form_with model: @recording, local: true do |f| %>
+    <div class="form-group">
+      <%= f.label :vocal_style, class: 'mb-1' %>
+      <%= f.text_field :vocal_style, class: 'form-control mb-3' %>
+      <%= f.label :instruments, class: 'mb-1' %>
+      <%= f.file_field :instruments, class: 'form-control mb-3' %>
+      <%= f.label :example_vocal, class: 'mb-1' %>
+      <%= f.file_field :example_vocal, class: 'form-control mb-4' %>
+    </div>
+    <%= f.submit class: 'btn btn-primary' %>
+  <% end %>
+</div>

--- a/app/views/recordings/show.html.erb
+++ b/app/views/recordings/show.html.erb
@@ -1,22 +1,43 @@
 <section class="recording">
-  <div class="container-fluid">
-    <div class="main-controls">
-      <div class="d-flex justify-content-center my-4">
-        <button id="js-permission-button" class="btn btn-warning">マイク許可</button>
-      </div>
-      <div class="d-flex justify-content-between">
-        <button id="js-record-button" class="btn btn-primary">録音</button>
-        <button id="js-stop-button" class="btn btn-danger">停止</button>
-      </div>
-      <div class="d-flex justify-content-center my-4">
-        <button id="js-playback-button" class="btn btn-success">再生</button>
-      </div>
+  <div class="container-fluid"> 
+    <h1 class="text-center my-5" style="font-size: 2rem">録音ページ（仮）</h1>
+
+    <div class="d-flex justify-content-center my-4">
+      <button id="js-permission-button" class="btn btn-warning">マイク許可</button>
     </div>
 
-    <div class="sound-clips">
-      <div class="d-flex justify-content-center">
-        <audio id="js-player" controls></audio>
-        <a id="js-download-link" type="hidden"></a>
+    <div class="row">
+      <div class="col-6">
+        <div class="controls">
+          <div class="d-flex justify-content-center my-2">
+            <button id="js-record-button" class="btn btn-primary">録音</button>
+          </div>
+          <div class="d-flex justify-content-center my-2">
+            <button id="js-stop-button" class="btn btn-danger">録音停止</button>
+          </div>
+          <div class="d-flex justify-content-center my-2">
+            <button id="js-playback-button" class="btn btn-success">再生</button>
+          </div>
+          <div class="sound-clips">
+            <div class="d-flex justify-content-center">
+              <audio id="js-player"></audio>
+              <a id="js-download-link" type="hidden"></a>
+            </div>
+          </div>
+        </div>
+      </div> 
+
+      <div class="col-6">
+        <div class="controls">
+          <div class="d-flex justify-content-center my-2">
+            <button id="js-example-button" class="btn btn-success">お手本再生</button>
+          </div>
+          <div class="sound-clips">
+            <div class="d-flex justify-content-center my-2">
+              <%= audio_tag("#{@recording.example_vocal.url}", id: 'js-example-player') %>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -26,6 +47,9 @@
         <%= f.hidden_field :recording_id, :value => @recording.id %>
         <%= f.hidden_field :vocal_data  %>
       <% end %>
+    </div>
+    <div class="text-center my-5">
+      <%= audio_tag("#{@recording.instruments.url}", id: 'js-instruments') %>
     </div>
   </div>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'static_pages#top'
 
-  resources :recordings, only: %i[index show] do
+  resources :recordings, only: %i[index show edit update] do
     resources :results, param: :uuid, only: %i[show create]
   end
 end

--- a/db/migrate/20220306154055_delete_instruments_uniq_index_from_recording.rb
+++ b/db/migrate/20220306154055_delete_instruments_uniq_index_from_recording.rb
@@ -1,0 +1,5 @@
+class DeleteInstrumentsUniqIndexFromRecording < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :recordings, :instruments
+  end
+end

--- a/db/migrate/20220306154230_delete_example_vocal_uniq_index_from_recording.rb
+++ b/db/migrate/20220306154230_delete_example_vocal_uniq_index_from_recording.rb
@@ -1,0 +1,5 @@
+class DeleteExampleVocalUniqIndexFromRecording < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :recordings, :example_vocal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_23_050325) do
+ActiveRecord::Schema.define(version: 2022_03_06_154230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,6 @@ ActiveRecord::Schema.define(version: 2022_02_23_050325) do
     t.string "instruments"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["example_vocal"], name: "index_recordings_on_example_vocal", unique: true
-    t.index ["instruments"], name: "index_recordings_on_instruments", unique: true
     t.index ["vocal_style"], name: "index_recordings_on_vocal_style", unique: true
   end
 


### PR DESCRIPTION
## 概要
close #28
- `Recording`モデルの`instruments`と`example_vocal`のカラムに音声データをCarrierWave経由でアップロード。
- 録音ページにそれぞれを埋め込みました。

## 確認方法
- `foreman start`でサーバー起動
- `http://localhost:3000/recordings/1`にアクセス
- 「お手本再生」ボタン押下>`example_vocal`の音声が再生されることを確認。
- `instruments`の音声は画面上で再生しないので非表示になっています。idが`js-instruments`になっているaudioタグがあるので、検証ツールなどを利用しそのタグのsrc属性にあるURLにアクセスし再生できるか確認。