### PR TITLE
Style: 録音ページのデザイン調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -119,9 +119,8 @@ a {
     overflow: scroll;
   }
 
-  button {
+  .btn {
     width: calc(45% - 1rem);
-
   }
 }
 

--- a/app/javascript/packs/voice.js
+++ b/app/javascript/packs/voice.js
@@ -9,8 +9,9 @@ const jsPlaybackButton = document.getElementById('js-playback-button');
 const jsPlayer = document.getElementById('js-player');
 const jsDownloadLink = document.getElementById('js-download-link');
 const jsResultButton = document.getElementById('js-result-button');
+const jsRetakeButton = document.getElementById('js-retake-button');
 const jsExampleButton = document.getElementById('js-example-button');
-const jsExamplePlayer = document.getElementById('js-example-player');
+const jsExampleVocalLink = document.getElementById('js-example-vocal-link');
 
 let audioData = [];
 let bufferSize = 1024;
@@ -113,6 +114,9 @@ jsPermissionButton.onclick = function() {
     })
 
     .then(function(audio) {
+      jsPermissionButton.classList.add('d-none');
+      jsRecordButton.classList.remove('d-none');
+
       stream = audio;
       console.log('録音可能です');
       return stream;
@@ -132,6 +136,9 @@ jsPermissionButton.onclick = function() {
 }
 
 jsRecordButton.onclick = function() {
+  jsRecordButton.classList.add('d-none');
+  jsStopButton.classList.remove('d-none');
+
   audioData = [];
   audioContext = new AudioContext();
   audioSampleRate = audioContext.sampleRate;
@@ -144,10 +151,11 @@ jsRecordButton.onclick = function() {
   jsRecordButton.disabled = true;
   jsStopButton.disabled = false;
   jsPlaybackButton.disabled = true;
+  jsExampleButton.disabled = true;
 
   timeout = setTimeout(() => {
     jsStopButton.click();
-  }, 5500);
+  }, 5000);
 
   jsStopButton.addEventListener('click', () => {
     clearTimeout(timeout);
@@ -156,11 +164,17 @@ jsRecordButton.onclick = function() {
 }
 
 jsStopButton.onclick = function() {
+  jsStopButton.classList.add('d-none');
+  jsPlaybackButton.classList.remove('d-none');
+  jsRetakeButton.classList.remove('d-none');
+  jsResultButton.classList.remove('d-none');
+
   saveAudio();
   jsRecordButton.disabled = false;
   jsStopButton.disabled = true;
   jsPlaybackButton.disabled = false;
   jsResultButton.disabled = false;
+  jsExampleButton.disabled = false;
 }
 
 jsPlaybackButton.onclick = function() {
@@ -175,11 +189,25 @@ jsPlaybackButton.onclick = function() {
 }
 
 jsExampleButton.onclick = function() {
-  jsExamplePlayer.play();
+  jsPlayer.src = jsExampleVocalLink.href;
+  jsPlayer.onended = function() {
+    jsPlayer.pause();
+    jsPlayer.src = ''
+  }
+  jsPlayer.play();
+}
+
+jsRetakeButton.onclick = function() {
+  jsRetakeButton.classList.add('d-none');
+  jsResultButton.classList.add('d-none');
+  jsPlaybackButton.classList.add('d-none');
+  jsRecordButton.classList.remove('d-none');
 }
 
 jsResultButton.onclick = function() {
   jsResultButton.disabled = true;
+  jsRetakeButton.disabled = true;
+
   let xhr = new XMLHttpRequest();
   xhr.open('GET', document.getElementById('js-download-link').href, true);
   xhr.responseType = 'blob';

--- a/app/views/recordings/show.html.erb
+++ b/app/views/recordings/show.html.erb
@@ -1,55 +1,49 @@
 <section class="recording">
   <div class="container-fluid"> 
-    <h1 class="text-center my-5" style="font-size: 2rem">録音ページ（仮）</h1>
-
-    <div class="d-flex justify-content-center my-4">
-      <button id="js-permission-button" class="btn btn-warning">マイク許可</button>
-    </div>
+    <h1 class="text-center mt-5 mb-3" style="font-size: 2rem">録音ページ（仮）</h1>
+    <h2 class="text-center mb-5"><%= @recording.vocal_style %>編</h2>
 
     <div class="row">
       <div class="col-6">
         <div class="controls">
-          <div class="d-flex justify-content-center my-2">
-            <button id="js-record-button" class="btn btn-primary">録音</button>
-          </div>
-          <div class="d-flex justify-content-center my-2">
-            <button id="js-stop-button" class="btn btn-danger">録音停止</button>
-          </div>
-          <div class="d-flex justify-content-center my-2">
-            <button id="js-playback-button" class="btn btn-success">再生</button>
-          </div>
-          <div class="sound-clips">
-            <div class="d-flex justify-content-center">
-              <audio id="js-player"></audio>
-              <a id="js-download-link" type="hidden"></a>
-            </div>
+          <div class="d-flex justify-content-center">
+            <button id="js-permission-button" class="btn btn-warning">マイク許可</button>
+            <button id="js-record-button" class="btn btn-primary d-none">録音開始</button>
+            <button id="js-stop-button" class="btn btn-danger d-none">録音停止</button>
+            <button id="js-playback-button" class="btn btn-success d-none">音声再生</button>
           </div>
         </div>
       </div> 
 
       <div class="col-6">
         <div class="controls">
-          <div class="d-flex justify-content-center my-2">
+          <div class="d-flex justify-content-center">
             <button id="js-example-button" class="btn btn-success">お手本再生</button>
-          </div>
-          <div class="sound-clips">
-            <div class="d-flex justify-content-center my-2">
-              <%= audio_tag("#{@recording.example_vocal.url}", id: 'js-example-player') %>
-            </div>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="d-flex justify-content-center my-5">
-      <button id="js-result-button" class="btn btn-primary">判定結果</button>
-      <%= form_with url: recording_results_path(@recording), id: "voiceform", local: true do |f| %>
-        <%= f.hidden_field :recording_id, :value => @recording.id %>
-        <%= f.hidden_field :vocal_data  %>
-      <% end %>
+    <div class="sound-clips my-4">
+      <div class="d-flex justify-content-center">
+        <audio id="js-player" controls></audio>
+
+        <a id="js-download-link" type="hidden"></a>
+        <%= link_to('', @recording.example_vocal.url, id: 'js-example-vocal-link', type: 'hidden') %>
+        <%= link_to('', @recording.instruments.url, id: 'js-instruments-link', type: 'hidden') %>
+      </div>
     </div>
-    <div class="text-center my-5">
-      <%= audio_tag("#{@recording.instruments.url}", id: 'js-instruments') %>
+
+    <div class="d-flex justify-content-center mt-5">
+      <button id="js-result-button" class="btn btn-primary d-none">判定結果</button>
+    </div>
+    <%= form_with url: recording_results_path(@recording), id: "voiceform", local: true do |f| %>
+      <%= f.hidden_field :recording_id, :value => @recording.id %>
+      <%= f.hidden_field :vocal_data %>
+    <% end %>
+
+    <div class="d-flex justify-content-center">
+      <button id="js-retake-button" class="btn btn-danger mt-3 d-none">やり直す</button>
     </div>
   </div>
 </section>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,11 @@
 <header class="header">
   <nav class="fixed-top navbar bg-dark">
     <div class="container-sm">
-      <%= link_to image_tag('header_logo.png', class: 'navbar-brand'), root_path %>
+      <% if current_page?(root_path) %>
+        <%= image_tag('header_logo.png', class: 'navbar-brand') %>
+      <% else %>
+        <%= link_to image_tag('header_logo.png', class: 'navbar-brand'), root_path %>
+      <% end %>
     </div>
   </nav>
 </header>


### PR DESCRIPTION
## 概要
close #32
- 録音ページに各ボタンが全て並んでいたので、クリックする毎に押せるボタンを出し分けするようにしました。
- ヘッダーのロゴについても、TOPページのみリンクをつけないようにしました。

## 備考
- デザインは確定しておらず、配色やレイアウトは今後さらにブラッシュアップする。