### PR TITLE
Feat: 録音ページ上に動的なメッセージを追加 #37

### DIFF
--- a/app/javascript/packs/voice.js
+++ b/app/javascript/packs/voice.js
@@ -12,6 +12,7 @@ const jsResultButton = document.getElementById('js-result-button');
 const jsRetakeButton = document.getElementById('js-retake-button');
 const jsExampleButton = document.getElementById('js-example-button');
 const jsExampleVocalLink = document.getElementById('js-example-vocal-link');
+const jsTimer = document.getElementById('js-timer');
 
 let audioData = [];
 let bufferSize = 1024;
@@ -22,6 +23,18 @@ let micBlobUrl = null;
 let scriptProcessor = null;
 let mediaStreamSource = null;
 let timeout = null;
+
+let stanby = function() {
+  jsTimer.innerHTML = '録音開始クリックと同時に歌おう！(最大5秒)';
+}
+
+let nowRecording = function() {
+  jsTimer.innerHTML = '録音中...終了まであと5秒';
+}
+
+let done = function() {
+  jsTimer.innerHTML = '録音完了！';
+}
 
 let onAudioProcess = function(e) {
   let input = e.inputBuffer.getChannelData(0);
@@ -107,6 +120,7 @@ jsPlaybackButton.disabled = true;
 jsResultButton.disabled = true;
 
 jsPermissionButton.onclick = function() {
+  jsPlayer.src = ''
   if(!stream) {
     navigator.mediaDevices.getUserMedia({
       video: false,
@@ -128,6 +142,7 @@ jsPermissionButton.onclick = function() {
     })
   }
 
+  stanby();
   jsPermissionButton.disabled = true;
   jsRecordButton.disabled = false;
   jsStopButton.disabled = true;
@@ -136,6 +151,7 @@ jsPermissionButton.onclick = function() {
 }
 
 jsRecordButton.onclick = function() {
+  jsPlayer.src = ''
   jsRecordButton.classList.add('d-none');
   jsStopButton.classList.remove('d-none');
 
@@ -153,12 +169,25 @@ jsRecordButton.onclick = function() {
   jsPlaybackButton.disabled = true;
   jsExampleButton.disabled = true;
 
+  nowRecording();
+  let sec = 4;
+  let countDownTime = setInterval(() => {
+    let remainingTime = sec--;
+    let string = `録音中...終了まであと${remainingTime}秒`;
+    jsTimer.innerHTML = string;
+    if (sec === 0) {
+      clearInterval(countDownTime);
+    }
+  }, 1000);
+
   timeout = setTimeout(() => {
     jsStopButton.click();
   }, 5000);
 
   jsStopButton.addEventListener('click', () => {
+    clearInterval(countDownTime);
     clearTimeout(timeout);
+    done();
     console.log('停止しました');
   });
 }
@@ -198,13 +227,17 @@ jsExampleButton.onclick = function() {
 }
 
 jsRetakeButton.onclick = function() {
+  jsPlayer.src = '';
   jsRetakeButton.classList.add('d-none');
   jsResultButton.classList.add('d-none');
   jsPlaybackButton.classList.add('d-none');
   jsRecordButton.classList.remove('d-none');
+
+  stanby();
 }
 
 jsResultButton.onclick = function() {
+  jsPlayer.src = '';
   jsResultButton.disabled = true;
   jsRetakeButton.disabled = true;
 

--- a/app/views/recordings/show.html.erb
+++ b/app/views/recordings/show.html.erb
@@ -3,6 +3,8 @@
     <h1 class="text-center mt-5 mb-3" style="font-size: 2rem">録音ページ（仮）</h1>
     <h2 class="text-center mb-5"><%= @recording.vocal_style %>編</h2>
 
+    <div class="text-center my-4"><span id="js-timer">マイクを許可してください</span></div>
+
     <div class="row">
       <div class="col-6">
         <div class="controls">


### PR DESCRIPTION
## 概要
close #37 
- 録音ページ上のボタンを押す毎にメッセージが変化するようにしました。
- 音声を再生中に`マイク許可`、`録音開始`、`やり直す`、`判定結果`を押した際、音声が自動停止するようにもしました。

## 詳細
下記の通りにメッセージが変化する
- 初期メッセージ：`マイクを許可してください`
- マイク許可orやり直すを押下：`録音開始クリックと同時に歌おう！(最大5秒)`
- 録音中：`録音中...終了まであと○秒`※5秒間カウントダウン
- 録音停止後：`録音完了！`