### PR TITLE
Recordingモデルのinstrumentsとexample_vocalにバリデーションを追加

### DIFF
--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -3,8 +3,8 @@
 # Table name: recordings
 #
 #  id            :bigint           not null, primary key
-#  example_vocal :string
-#  instruments   :string
+#  example_vocal :string           not null
+#  instruments   :string           not null
 #  vocal_style   :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -19,4 +19,6 @@ class Recording < ApplicationRecord
   mount_uploader :example_vocal, ExampleVocalUploader
 
   validates :vocal_style, presence: true, uniqueness: true
+  validates :example_vocal, presence: true
+  validates :instruments, presence: true
 end

--- a/db/migrate/20220311005408_change_recordings_example_vocal_and_insruments_not_null.rb
+++ b/db/migrate/20220311005408_change_recordings_example_vocal_and_insruments_not_null.rb
@@ -1,0 +1,11 @@
+class ChangeRecordingsExampleVocalAndInsrumentsNotNull < ActiveRecord::Migration[6.1]
+  def up
+    change_column_null :recordings, :example_vocal, false
+    change_column_null :recordings, :instruments, false
+  end
+
+  def down
+    change_column_null :recordings, :example_vocal, true
+    change_column_null :recordings, :instruments, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_06_154230) do
+ActiveRecord::Schema.define(version: 2022_03_11_005408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "recordings", force: :cascade do |t|
     t.string "vocal_style", null: false
-    t.string "example_vocal"
-    t.string "instruments"
+    t.string "example_vocal", null: false
+    t.string "instruments", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["vocal_style"], name: "index_recordings_on_vocal_style", unique: true


### PR DESCRIPTION
close #41 
- `instruments`と`example_vocal`には常にデータが存在していないと録音機能が成立しない
- その為、DB側でNot Null制約を、モデル側で`presence: true`を追加しました。