### PR TITLE
各モデルに必要なDB上の制約・バリデーションを設定

### DIFF
--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -3,11 +3,11 @@
 # Table name: recordings
 #
 #  id               :bigint           not null, primary key
-#  embed_identifier :string
+#  embed_identifier :string           not null
 #  emotion          :integer          default("angry"), not null
 #  example_vocal    :string           not null
-#  summary          :string
-#  vocal_image      :string
+#  summary          :string           not null
+#  vocal_image      :string           not null
 #  vocal_style      :string           not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -24,6 +24,9 @@ class Recording < ApplicationRecord
   validates :vocal_style, presence: true, uniqueness: true
   validates :example_vocal, presence: true
   validates :emotion, presence: true
+  validates :vocal_image, presence: true
+  validates :summary, presence: true, length: { maximum: 255 }
+  validates :embed_identifier, presence: true
 
   enum emotion: { angry: 0, sad: 10, happy: 20, disgust: 30, surprise: 40, neutral: 50, fear: 60 }
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -3,10 +3,10 @@
 # Table name: results
 #
 #  id               :bigint           not null, primary key
-#  compose_song     :string
-#  emotion_strength :string
+#  compose_song     :string           not null
+#  emotion_strength :string           not null
 #  uuid             :string           not null
-#  vocal_data       :string
+#  vocal_data       :string           not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  recording_id     :bigint           not null

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -25,6 +25,11 @@ class Result < ApplicationRecord
   mount_uploader :vocal_data, VocalDataUploader
   mount_uploader :compose_song, ComposeSongUploader
 
+  validates :uuid, presence: true, uniqueness: true
+  validates :vocal_data, presence: true
+  validates :compose_song, presence: true
+  validates :emotion_strength, presence: true
+
   def score
     parse = JSON.parse(emotion_strength)
     parse['emotion_detail'][recording.emotion] * 100

--- a/db/migrate/20220328073935_change_recordings_and_results_columns_not_null.rb
+++ b/db/migrate/20220328073935_change_recordings_and_results_columns_not_null.rb
@@ -1,0 +1,21 @@
+class ChangeRecordingsAndResultsColumnsNotNull < ActiveRecord::Migration[6.1]
+  def up
+    change_column_null :recordings, :embed_identifier, false
+    change_column_null :recordings, :summary, false
+    change_column_null :recordings, :vocal_image, false
+
+    change_column_null :results, :compose_song, false
+    change_column_null :results, :emotion_strength, false
+    change_column_null :results, :vocal_data, false
+  end
+  
+  def down
+    change_column_null :recordings, :embed_identifier, true
+    change_column_null :recordings, :summary, true
+    change_column_null :recordings, :vocal_image, true
+
+    change_column_null :results, :compose_song, true
+    change_column_null :results, :emotion_strength, true
+    change_column_null :results, :vocal_data, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_27_155333) do
+ActiveRecord::Schema.define(version: 2022_03_28_073935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,18 +21,18 @@ ActiveRecord::Schema.define(version: 2022_03_27_155333) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "emotion", default: 0, null: false
-    t.string "vocal_image"
-    t.string "summary"
-    t.string "embed_identifier"
+    t.string "vocal_image", null: false
+    t.string "summary", null: false
+    t.string "embed_identifier", null: false
     t.index ["vocal_style"], name: "index_recordings_on_vocal_style", unique: true
   end
 
   create_table "results", force: :cascade do |t|
     t.bigint "recording_id", null: false
     t.string "uuid", null: false
-    t.string "vocal_data"
-    t.string "compose_song"
-    t.string "emotion_strength"
+    t.string "vocal_data", null: false
+    t.string "compose_song", null: false
+    t.string "emotion_strength", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["recording_id"], name: "index_results_on_recording_id"


### PR DESCRIPTION
## 概要
close #75 
- 開発工程で設定していなかったDB上の制約・バリデーションを設定。
- NotNull制約、presence: trueを追加
  - Recordingモデル
    - vocal_image
    - summary
    - embed_identifier
  - Resultモデル
    - vocal_data
    - compose_song
    - emotion_strength

- presence: true, uniqueness: trueを追加
  - Resultモデル：uuid

- lengthの上限値を設定
  - Recordingモデル：summary

## 備考
- uuidはバリデーションのし忘れだったので、このタイミングで設定。
- 基本的にnullになることを想定しているカラムは殆どないため、全体的にNotNull制約をかけています。
   