### PR TITLE
Feat: Twitterシェア用のリンクを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,6 +58,10 @@ a {
     display: inline-block;
     width: 222px;
     height: 46px;
+    @include media(sp) {
+      width: 177px;
+      height: 37px;
+    }
   }
 }
 
@@ -79,7 +83,7 @@ a {
   &-title {
     img {
       display: inline-block;
-      max-width: 95%
+      max-width: 95%;
     }
   }
 
@@ -228,11 +232,9 @@ a {
     border-radius: 19px;
     color: $main_color_text;
     background-color: #b40000;
-    border-color: #b8003a;
 
     &:hover {
       background-color: #b82828;
-      border-color: #af2121;
     }
 
     &:focus {
@@ -241,7 +243,18 @@ a {
 
     &:active {
       background-color: #f03636;
-      border-color: #c52b2b;
+    }
+
+    &-twitter {
+      background-color: #1d9bf0;
+
+      &:hover {
+        background-color: #188CD8;
+      }
+
+      &:focus {
+        box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+      }
     }
   }
 }

--- a/app/services/result_display_service.rb
+++ b/app/services/result_display_service.rb
@@ -8,19 +8,19 @@ class ResultDisplayService
       {
         score: (@result.created_at.strftime('%S')[1].to_i).ceil(0),
         evaluation: 'Keep trying!',
-        comment: 'お手本を聴いて再チャレンジ！'
+        comment: '残念！練習して再チャレンジ！'
       }
     elsif @result.score.ceil(0).positive? && @result.score.ceil(0) < 20
       {
         score: @result.score.ceil(0),
         evaluation: 'Keep trying!',
-        comment: 'お手本を聴いて再チャレンジ！'
+        comment: '残念！練習して再チャレンジ！'
       }
     elsif @result.score.ceil(0) >= 20 && @result.score.ceil(0) < 40
       {
         score: @result.score.ceil(0),
         evaluation: 'OK!',
-        comment: 'もっといけそうです！練習してみましょう！'
+        comment: 'もっといけそうです！その調子で練習を重ねましょう！'
       }
     elsif @result.score.ceil(0) >= 40 && @result.score.ceil(0) < 60
       {

--- a/app/views/recordings/_recording.html.erb
+++ b/app/views/recordings/_recording.html.erb
@@ -5,7 +5,7 @@
         <%= image_tag(recording.vocal_image.url, class: 'card-img-top') %>
         <div class="card-body text-center">
           <h2 class="h5"><%= recording.vocal_style %></h2>
-          <small class="text-muted text-nowrap"><%= recording.summary %></small>
+          <p><small class="text-muted text-nowrap"><%= recording.summary %></small></p>
         </div>
       </div>
     <% end %>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -29,9 +29,13 @@
         </div>
       </div>
 
-      <div class="d-flex justify-content-center flex-column align-items-center">
-        <%= link_to t('.to_recordings_page'), recordings_path, class: 'btn mb-3' %>
-        <%= link_to t('.to_top_page'), root_path, class: 'btn', data: { turbolinks: false } %>
+      <%= link_to "https://twitter.com/share?url=#{request.protocol}#{request.host}&hashtags=GruntChecker&text=【#{@result.recording.vocal_style}】に挑戦しました！%0a%0a結果は… #{@display[:score]}点/100点でした！%0a#{@display[:comment]}%0a%0a↓デスボイスに挑戦してみる%0a", class: 'btn btn-twitter mb-4', target: '_blank', rel: 'noopener noreferrer' do %>
+        <i class="fab fa-twitter pe-1"></i><%= t('.share_to_twitter') %>
+      <% end %>
+
+      <div class="d-flex justify-content-center align-items-center mb-4">
+        <%= link_to t('.to_recordings_page'), recordings_path, class: 'btn mx-2' %>
+        <%= link_to t('.to_top_page'), root_path, class: 'btn mx-2', data: { turbolinks: false } %>
       </div>
     </div>
   </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,3 +40,4 @@ ja:
       title: '測定結果'
       to_recordings_page: 'ステージ選択へ'
       to_top_page: 'TOPへ'
+      share_to_twitter: '結果をシェア'


### PR DESCRIPTION
## 概要
close #85 
- 測定結果のページにTwitterシェア用のリンクを追加
- シェアする範囲は採点結果のみにした。音声が含まれるページのリンクはシェアに含めない。（TOPページへのリンクは記載）
理由：演奏と合わせた音声の形式がブラウザの作りに依存するようになっている。そのため、ブラウザをまたぐと再生が上手く動作しない可能性があり、混乱の種になる恐れがある。