### PR TITLE
Perf: ステージ選択画面のRecordingモデルをcreated_atの昇順に固定

### DIFF
--- a/app/controllers/recordings_controller.rb
+++ b/app/controllers/recordings_controller.rb
@@ -4,7 +4,7 @@ class RecordingsController < ApplicationController
   before_action :admin_scan, only: %i[create update]
 
   def index
-    @recordings = Recording.all
+    @recordings = Recording.all.order(created_at: :asc)
   end
 
   def new


### PR DESCRIPTION
## 概要
close #108 
- `RecordingsController`の`index`アクションにある`Recording.all`に`order`メソッドを追加。
- `created_at`の昇順で並び順が固定されるように変更。