### PR TITLE
Feat: 測定結果のページから録音ページに戻る「もう一度挑戦」ボタンを追加

### DIFF
--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -34,6 +34,7 @@
       <% end %>
 
       <div class="d-flex justify-content-center align-items-center mb-4">
+        <%= link_to t('.retry'), recording_path(@result.recording_id), class: 'btn mx-2' %>
         <%= link_to t('.to_recordings_page'), recordings_path, class: 'btn mx-2' %>
         <%= link_to t('.to_top_page'), root_path, class: 'btn mx-2', data: { turbolinks: false } %>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,4 +40,5 @@ ja:
       title: '測定結果'
       to_recordings_page: 'ステージ選択へ'
       to_top_page: 'TOPへ'
+      retry: 'もう一度挑戦'
       share_to_twitter: '結果をシェア'


### PR DESCRIPTION
## 概要
close #110 
- 測定結果のページでURLヘルパーメソッド`recording_path(@result.recording_id)`を使用してリンクタグを追加