### PR TITLE
Test: 管理画面へのログイン・ページ遷移のシステムスペックを作成

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user_#{n}@example.com" }
+    password { "password" }
+    password_confirmation { "password" }
+    role { :general }
+  end
+
+  trait :admin do
+    sequence(:email) { |n| "admin_#{n}@example.com" }
+    role { :admin }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,4 +71,5 @@ RSpec.configure do |config|
   end
 
   config.include FactoryBot::Syntax::Methods
+  config.include LoginMacros
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,0 +1,8 @@
+module LoginMacros
+  def login_as(user)
+    visit admin_root_path
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
+    click_button 'ログイン'
+  end
+end

--- a/spec/system/admin_recordings_spec.rb
+++ b/spec/system/admin_recordings_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "AdminRecordings", type: :system do
+  let(:admin) { create :user, :admin }
+  let(:recording) { create(:recording) }
+
+  describe 'ログイン前' do
+    context 'ページ遷移確認' do
+      it 'ステージ一覧ページへのアクセスに失敗する' do
+        visit admin_recordings_path
+        expect(page).to have_content 'ログインしてください'
+        expect(current_path).to eq admin_login_path
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    before { login_as(admin) }
+    context 'ページ遷移確認' do
+      it 'ステージ一覧画面が表示される' do
+        recording
+        visit admin_recordings_path
+        expect(page).to have_content recording.vocal_style
+        expect(Recording.count).to eq 1
+        expect(current_path).to eq admin_recordings_path
+      end
+
+      it 'ステージ詳細画面が表示される' do
+        visit admin_recording_path(recording)
+        expect(page).to have_content recording.vocal_style
+        expect(current_path).to eq admin_recording_path(recording)
+      end
+    end
+  end
+end

--- a/spec/system/admin_user_sessions_spec.rb
+++ b/spec/system/admin_user_sessions_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "AdminUserSessions", type: :system do
+  let(:admin) { create :user, :admin }
+
+  describe 'ログイン前' do
+    context 'フォームの入力値が正常' do
+      it 'ログイン処理が成功する' do
+        visit admin_login_path
+        fill_in 'メールアドレス', with: admin.email
+        fill_in 'パスワード', with: 'password'
+        click_button 'ログイン'
+        expect(page).to have_content 'ログインしました'
+        expect(current_path).to eq admin_root_path
+      end
+    end
+
+    context 'フォームが未入力' do
+      it 'ログイン処理が失敗する' do
+        visit admin_login_path
+        fill_in 'メールアドレス', with: ''
+        fill_in 'パスワード', with: 'password'
+        click_button 'ログイン'
+        expect(page).to have_content 'ログインに失敗しました'
+        expect(current_path).to eq admin_login_path
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    context 'ログアウトボタンをクリック' do
+      it 'ログアウト処理が成功する' do
+        login_as(admin)
+        visit admin_root_path
+        click_link 'ログアウト'
+        expect(page).to have_content 'ログアウトしました'
+        expect(current_path).to eq admin_login_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
close #100
- `spec/support/login_macros.rb`を作成した。
- `spec/rails_helper.rb`にIncludeした。
- 以下のシステムスペックを作成した。
  - `spec/system/admin_user_sessions_spec.rb`
  - `spec/system/admin_recordings_spec.rb`
- FactoryBotを使用し、 Userモデルのダミーデータを作成した。

## 確認方法
- `bundle exec rspec`を実行し、テストがパスするか確認。
- その後`coverage/index.html`が作成される為、`open`しカバレッジを確認。

### テスト結果
[![Image from Gyazo](https://i.gyazo.com/38f4eb337b09300de05c59230fc2bb10.png)](https://gyazo.com/38f4eb337b09300de05c59230fc2bb10)

### 現在のカバレッジ
[![Image from Gyazo](https://i.gyazo.com/d3b160623cd06ab39df09773585afe37.png)](https://gyazo.com/d3b160623cd06ab39df09773585afe37)