### PR TITLE
Refactor: createアクションに記載されたAPIからデータを取得する処理をモデル側に移行 #119

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -6,20 +6,9 @@ class ResultsController < ApplicationController
   end
 
   def create
-    url = ENV['API_URL']
-    vocal = File.new(params[:vocal_data])
-    response = RestClient::Request.execute(
-      method: :post,
-      url: url,
-      payload: {
-        multipart: true,
-        api_key: ENV['API_KEY'],
-        voice_data: vocal
-      },
-      content_type: 'audio/wav'
-    )
-
-    result = Result.create(result_params.merge(uuid: SecureRandom.uuid, emotion_strength: response.body))
+    result = Result.new(result_params.merge(uuid: SecureRandom.uuid))
+    result.vocal_params = params[:vocal_data]
+    result.save!
     render json: { url: result_path(result.uuid) }
   end
 

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -25,13 +25,35 @@ class Result < ApplicationRecord
   mount_uploader :vocal_data, VocalDataUploader
   mount_uploader :compose_song, ComposeSongUploader
 
+  before_validation :vocal_analyse
+
   validates :uuid, presence: true, uniqueness: true
   validates :vocal_data, presence: true
   validates :compose_song, presence: true
   validates :emotion_strength, presence: true
 
+  attr_writer :vocal_params
+
   def score
     parse = JSON.parse(emotion_strength)
     parse['emotion_detail'][recording.emotion] * 100
+  end
+
+  private
+
+  def vocal_analyse
+    url = ENV['API_URL']
+    vocal = File.new(@vocal_params)
+    response = RestClient::Request.execute(
+      method: :post,
+      url: url,
+      payload: {
+        multipart: true,
+        api_key: ENV['API_KEY'],
+        voice_data: vocal
+      },
+      content_type: 'audio/wav'
+    )
+    self.emotion_strength = response.body
   end
 end


### PR DESCRIPTION
#118
close #119
- Resultモデル側に`attr_writer`を記載し、コントローラ側の`params[:vocal_data]`の値を取得
- コントローラの`create`アクションに記述したAPIからデータを取得処理をモデル側にインスタンスメソッド`vocal_analyse`に切り出し
- `vocal_analyse`が`before_validation`のタイミングでコールバックされるようにした